### PR TITLE
Remove point 3.3 of Deals T&C #163

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/src/components/BirthdayDeal/BirthdayDeal.js
+++ b/src/components/BirthdayDeal/BirthdayDeal.js
@@ -118,11 +118,6 @@ const BirthdayDeal  = props => {
 							<ol>
 								<li>A refund goes back to the same payment method used to request the booking;</li>
 								<li>A refund might take between 7-15 business days. The speed depends entirely on your financial institution;</li>
-								<li>The refund benefit is only valid for listings that are managed by Whichost.
-									<ol>
-										<li>You can find this information at the bottom of the description of the listing. If it's managed by Whichost it will say: <b>“This listing is managed by Whichost.”</b></li>
-									</ol>
-								</li>
 							</ol>
 
 						</li>

--- a/src/components/CorporateDeal/CorporateDeal.js
+++ b/src/components/CorporateDeal/CorporateDeal.js
@@ -97,11 +97,6 @@ const CorporateDeal = props => {
 			<ol>
 				<li>A refund goes back to the same payment method used to request the booking;</li>
 				<li>A refund might take between 7-15 business days. The speed depends entirely on the financial institution used by the employee;</li>
-				<li>The refund benefit is only valid for listings that are managed by Whichost.
-					<ol>
-						<li>The employee can find this information at the bottom of the description of the listing. If it's managed by Whichost it will say: <b>“This listing is managed by Whichost.”</b></li>
-					</ol>
-				</li>
 			</ol>
 
 		</li>


### PR DESCRIPTION
This fixes issue #163. 
**What have been done**: We removed point 3.3 from Corporate and Birthday deals Terms and Conditions
**Pushed to**: `delete-point-3-3-from-deals-t-c`
**Tag somebody**: @RohrerHope 

![image](https://user-images.githubusercontent.com/1237971/56863530-2d32ad80-69af-11e9-8095-47f858d5a98f.png)

Test on https://whichost-frontend-staging.herokuapp.com/deals/corporate-deal and https://whichost-frontend-staging.herokuapp.com/deals/birthday-deal