### PR TITLE
Add recommend gift link when no pubs found

### DIFF
--- a/src/components/SearchFiltersMobile/SearchFiltersMobile.js
+++ b/src/components/SearchFiltersMobile/SearchFiltersMobile.js
@@ -165,10 +165,8 @@ class SearchFiltersMobileComponent extends Component {
     const RecommendDeal = props =>
       recommendDealActive && props.show ? (
         <p className={css.recommendDeal}>
-          <FormattedMessage id="SearchFilters.recommendDealLabel" />
-          &nbsp;
           <NamedLink name="RecommendDealPage">
-            <FormattedMessage id="SearchFilters.recommendDealLink" />
+            <FormattedMessage id="SearchFilters.recommendDealLabel" />
           </NamedLink>
         </p>
       ) : null;

--- a/src/containers/Legals/tabs.js
+++ b/src/containers/Legals/tabs.js
@@ -18,12 +18,13 @@ export const legalsTabs = (intl, selected) => [
 		selected: (selected == 'LegalsDealsPage'),
 		linkProps: {
 			name: 'LegalsDealsPage',
+		}
   },
   {
 		text: intl.formatMessage({ id: 'LegalsPages.communityGuidelinesTabTitle'}),
 		selected: (selected == 'CommunityGuidelinesPage'),
 		linkProps: {
 			name: 'CommunityGuidelinesPage',
-		},
+		}
 	}
 ]

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -712,7 +712,7 @@
   "ReviewModal.title": "Leave a review for {revieweeName}",
 
   "Reviews.bannedUserDisplayName": "Banned user",
-  "SearchFilters.recommendDealLabel": "Earn a gift card to use over 2.000 shops! Get €15 for recommending a pub and celebrate there.",
+  "SearchFilters.recommendDealLabel": "Click here to earn a gift card for over 2.000 shops! Get €15 for recommending a pub and celebrate there.",
   "SearchFilters.recommendDealLink": "Learn More…",
 
   "SearchFilters.amenitiesLabel": "Amenities",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -725,7 +725,7 @@
   "SearchFilters.loadingResultsMobile": "Loading…",
   "SearchFilters.moreFiltersButton": "{count, plural, =0 {More filters} other {More filters • #}}",
   "SearchFilters.noResults": "Whoops! No pubs listed here yet, but you can still celebrate.",
-  "SearchFilters.noResultsMobile": "No pubs listed here.",
+  "SearchFilters.noResultsMobile": "Whoops! No pubs here yet.",
   "SearchFilters.openMapView": "Map",
 
   "SearchFiltersMobile.amenitiesLabel": "Amenities",


### PR DESCRIPTION
**What have been done**: We updated the message on mobile and removed the "Learn more" link. The whole message is not a link.
![image](https://user-images.githubusercontent.com/1237971/57180607-41c8e700-6e82-11e9-85be-5b3046c9b51f.png)

**Pushed to**: `add-recommend-gift-link-when-no-pubs-found`
**Tag somebody**: @RohrerHope 
**Where to test**: https://whichost-frontend-stagi-pr-183.herokuapp.com/