### PR TITLE
Replace links to contact us page

### DIFF
--- a/src/components/PrivacyPolicy/PrivacyPolicy.js
+++ b/src/components/PrivacyPolicy/PrivacyPolicy.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+import { NamedLink } from '../../components';
+
 import css from './PrivacyPolicy.css';
 
 const PrivacyPolicy = props => {
@@ -22,7 +24,7 @@ const PrivacyPolicy = props => {
       </p>
       
       <p>
-      If you have questions about this Privacy Policy or our use of personal information, please email us at <a href="mailto:support@whichost.com">support@whichost.com</a>. Your use of the website or Services constitutes your acceptance of our use of your personal information as described in this Privacy Policy.
+				If you have questions about this Privacy Policy or our use of personal information, please <NamedLink name="ContactUsPageEnquiry" params={{enquiry: "privacy"}}>contact us</NamedLink>. Your use of the website or Services constitutes your acceptance of our use of your personal information as described in this Privacy Policy.
       </p>
 
       <h2>COLLECTION OF INFORMATION</h2>
@@ -33,8 +35,7 @@ const PrivacyPolicy = props => {
 
       <h3>Not for use for people under the age of 18 years old</h3>
       <p>
-        The Services are not intended for people under 18 years of age. If you are under 18, do not use or provide any personal information on or through the Services or about yourself to us. If you believe that we might have personal information from or about a child under 18, please email us at <a href="mailto:support@whichost.com">support@whichost.com</a>.
-      </p>
+				The Services are not intended for people under 18 years of age. If you are under 18, do not use or provide any personal information on or through the Services or about yourself to us. If you believe that we might have personal information from or about a child under 18, please <NamedLink name="ContactUsPageEnquiry" params={{enquiry: "privacy"}}>contact us</NamedLink>.</p>
 
       <h3>Information we collect automatically when you use our services</h3>
       <p>
@@ -97,7 +98,7 @@ Whichost takes reasonable measures to help protect personal information from los
 		<h2>YOUR CHOICES</h2>
 		<h3>Account information</h3>
 		<p>
-You may update, correct or delete personal information at any time by emailing us at <a href="mailto:support@whichost.com">support@whichost.com</a>. If you wish to delete or deactivate your account, you can do so by emailing us, but we may retain certain personal information as required by law or for legitimate business purposes. We may also retain cached or archived copies of your personal information until purged during our normal course of business.
+			You may update, correct or delete personal information at any time by <NamedLink name="ContactUsPageEnquiry" params={{enquiry: "privacy"}}>clicking here</NamedLink>. If you wish to delete or deactivate your account, you can do so by emailing us, but we may retain certain personal information as required by law or for legitimate business purposes. We may also retain cached or archived copies of your personal information until purged during our normal course of business.
 		</p>
 		<h3>Cookies</h3>
 		<p>
@@ -105,11 +106,11 @@ Most web browsers are set to accept cookies by default. If you prefer, you can u
 		</p>
 		<h3>Promotional communications</h3>
 		<p>
-You may opt out of receiving promotional communications from Whichost by following the unsubscribe instructions in those communications or by emailing us at <a href="mailto:support@whichost.com">support@whichost.com</a>. If you opt out, we may still send you non-promotional communications, including those about your account or transactions.
+			You may opt out of receiving promotional communications from Whichost by following the unsubscribe instructions in those communications or by <NamedLink name="ContactUsPageEnquiry" params={{enquiry: 'privacy'}}>clicking here</NamedLink>. If you opt out, we may still send you non-promotional communications, including those about your account or transactions.
 		</p>
 		<h3>Contact information</h3>
 		<p>
-Please email us at <a href="mailto:support@whichost.com">support@whichost.com</a> with any questions or comments about this Privacy Policy.
+			Please <NamedLink name="ContactUsPageEnquiry" params={{enquiry: "privacy"}}>contact us</NamedLink> with any questions or comments about this Privacy Policy.
 		</p>
     </div>
   );

--- a/src/containers/HelpCenter/ContactUsPage/ContactUsPage.duck.js
+++ b/src/containers/HelpCenter/ContactUsPage/ContactUsPage.duck.js
@@ -87,7 +87,8 @@ export const sendContactUsMessage = params => (dispatch, getState, sdk) => {
     recaptchaToken: params.recaptchaToken,
   };
 
-  console.log(config.serviceMessageUrl);
+  console.log('data', data);
+
   return fetch(config.serviceMessageUrl, {
     method: 'post',
     body: JSON.stringify(data),

--- a/src/containers/HelpCenter/ContactUsPage/ContactUsPage.js
+++ b/src/containers/HelpCenter/ContactUsPage/ContactUsPage.js
@@ -60,11 +60,14 @@ const ContactUsPageComponent = props => {
     name: schemaTitle,
   };
 
+	const injectUserEmail = (values, user) => 
+		user.id? {...values, email: user.attributes.email} : values;	
+
   const contactUsForm = (
     <ContactUsForm
       className={css.form}
       initialValues={initialValues}
-      onSubmit={values => onSendMessage(values)}
+      onSubmit={values => onSendMessage(injectUserEmail(values, currentUser))}
       sendingInProgress={sendingInProgress}
       sendingError={sendingError}
       currentUser={currentUser}

--- a/src/containers/HelpCenter/FAQPage/FAQPage.js
+++ b/src/containers/HelpCenter/FAQPage/FAQPage.js
@@ -158,7 +158,9 @@ class FAQPagePanelsBase extends React.Component {
                 <li>The customers internal account will be updated with the No-Show;</li>
                 <li>Once a customer accumulates 4 (four) No-Shows, their account is suspended.</li>
               </ol>
-              <a href="https://docs.google.com/forms/d/1jZ1aH21YDcqelSC3F7628ZWxvOZR2QPacA5lRV8O70c/edit">Report a No-Show</a>
+              <a href="https://docs.google.com/forms/d/1jZ1aH21YDcqelSC3F7628ZWxvOZR2QPacA5lRV8O70c/edit">
+                Report a No-Show
+              </a>
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -267,8 +269,11 @@ class FAQPagePanelsBase extends React.Component {
               <a href="mailto:support@whichost.com?subject=Help Center Question" target="_blank">
                 support@whichost.com
               </a>{' '}
-              or by clicking <NamedLink name="ContactUsPage">here</NamedLink>. We'll be happy to
-              answer all of your questions.
+              or by clicking{' '}
+              <NamedLink name="ContactUsPage" enquiry="general">
+                here
+              </NamedLink>
+              . We'll be happy to answer all of your questions.
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -328,7 +333,10 @@ class FAQPagePanelsBase extends React.Component {
               a Whichost account, simply click the “+ Add my pub” at the top right. Please note that
               all listings are subject to review by our team to ensure the safety of our community.
               If you need help with your listing, please{' '}
-              <NamedLink name="ContactUsPage">click here</NamedLink> or email us at{' '}
+              <NamedLink name="ContactUsPageEnquiry" params={{ enquiry: 'listing' }}>
+                click here
+              </NamedLink>{' '}
+              or email us at{' '}
               <a
                 href="mailto:support@whichost.com?subject=How do I list my pub inquiry"
                 target="_blank"
@@ -512,7 +520,11 @@ class FAQPagePanelsBase extends React.Component {
               <br />
               <br />
               In the case that you don't have quality images of your space(s) and need help with it,
-              please contact us <NamedLink name="ContactUsPage">here</NamedLink> or at{' '}
+              please contact us{' '}
+              <NamedLink name="ContactUsPageEnquiry" params={{ enquiry: 'listing' }}>
+                here
+              </NamedLink>{' '}
+              or at{' '}
               <a href="mailto:support@whichost.com" target="_blank">
                 support@whichost.com
               </a>{' '}
@@ -566,7 +578,9 @@ class FAQPagePanelsBase extends React.Component {
               We do advise users to cancel as soon as possible to not affect your operation.
               <br />
               <br /> If a customer booked your space b ut they didn't showed up, we reccomend you to{' '}
-              <a href="https://docs.google.com/forms/d/1jZ1aH21YDcqelSC3F7628ZWxvOZR2QPacA5lRV8O70c/edit">Report a No-Show.</a>
+              <a href="https://docs.google.com/forms/d/1jZ1aH21YDcqelSC3F7628ZWxvOZR2QPacA5lRV8O70c/edit">
+                Report a No-Show.
+              </a>
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -655,13 +669,10 @@ class FAQPagePanelsBase extends React.Component {
                 </li>
               </ol>
               If at any time you need help with this, please{' '}
-              <NamedLink name="ContactUsPage">click here</NamedLink> or email us at{' '}
-              <a
-                href="mailto:support@whichost.com?subject=Adding my payout information"
-                target="_blank"
-              >
-                support@whichost.com
-              </a>
+              <NamedLink name="ContactUsPageEnquiry" params={{ enquiry: 'changePaymentInfo' }}>
+                click here
+              </NamedLink>
+              .
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -757,10 +768,7 @@ class FAQPagePanelsBase extends React.Component {
           <ExpansionPanelDetails>
             <Typography>
               Currently, it is not possible to edit or delete reviews. If there is an issue with a
-              review, you can email us at{' '}
-              <a href="mailto:support@whichost.com?subject=Review Dispute inquiry" target="_blank">
-                support@whichost.com
-              </a>{' '}
+              review, you can contact us <NamedLink name="ContactUsPage">here</NamedLink>
               and we'll be happy to help.
             </Typography>
           </ExpansionPanelDetails>
@@ -812,14 +820,8 @@ class FAQPagePanelsBase extends React.Component {
               <br />
               If you want your customers to be able to book your additional services (like finger
               food or drink vouchers) directly during the initial booking process, please send us a
-              feedback at{' '}
-              <a
-                href="mailto:feedback@whichost.com?subject=Additional Services Feedback"
-                target="_blank"
-              >
-                feedback@whichost.com
-              </a>
-              . We appreciate every piece of feedback that we receive from you!
+              feedback <NamedLink name="ContactUsPage">here</NamedLink>. We appreciate every piece
+              of feedback that we receive from you!
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -848,15 +850,8 @@ class FAQPagePanelsBase extends React.Component {
             <Typography>
               We let pubs exchange messages with customers and bookings directly to communicate
               availability, changes in dates, booking modifications, and also cancellations. In the
-              event that this can not be agreed upon directly with a customer and pub, you can email
-              us at{' '}
-              <a
-                href="mailto:support@whichost.com?subject=Cancellation Policy Request"
-                target="_blank"
-              >
-                support@whichost.com
-              </a>{' '}
-              directly.
+              event that this can not be agreed upon directly with a customer and pub, you can{' '}
+              <NamedLink name="ContactUsPage">contact us</NamedLink>
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -876,11 +871,7 @@ class FAQPagePanelsBase extends React.Component {
               then quicker for following transfers. This process is handled by Stripe. Rest assured
               that once you accept a booking request, the person that booked your pub has been
               charged for the booking and paid for it. If you have any questions about this at any
-              time, please email us at{' '}
-              <a href="mailto:support@whichost.com?subject=Payout Inquiry" target="_blank">
-                support@whichost.com
-              </a>
-              .
+              time, please <NamedLink name="ContactUsPage">contact us</NamedLink>.
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -906,11 +897,8 @@ class FAQPagePanelsBase extends React.Component {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <Typography>
-              Please, feel free to contact us at{' '}
-              <a href="mailto:support@whichost.com?subject=Help Center Question" target="_blank">
-                support@whichost.com
-              </a>
-              . We'll be happy to answer all of your questions.
+              Please, feel free to contact us <NamedLink name="ContactUsPage">here</NamedLink>.
+              We'll be happy to answer all of your questions.
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -1127,11 +1115,8 @@ class FAQPagePanelsBase extends React.Component {
           <ExpansionPanelDetails>
             <Typography>
               Currently, it is not possible to edit or delete reviews. If there is an issue with a
-              review, you can email us at{' '}
-              <a href="mailto:support@whichost.com?subject=Review Dispute inquiry" target="_blank">
-                support@whichost.com
-              </a>{' '}
-              and we'll be happy to help.
+              review, you can email us <NamedLink name="ContactUsPage">here</NamedLink> and we'll be
+              happy to help.
             </Typography>
           </ExpansionPanelDetails>
         </ExpansionPanel>
@@ -1238,7 +1223,7 @@ class FAQPagePanelsBase extends React.Component {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <Typography>
-							Please, feel free to contact us <NamedLink name="ContactUsPage">here</NamedLink> at{' '}
+              Please, feel free to contact us <NamedLink name="ContactUsPage">here</NamedLink> at{' '}
               <a href="mailto:support@whichost.com?subject=Help Center Question" target="_blank">
                 support@whichost.com
               </a>
@@ -1296,13 +1281,8 @@ class FAQPagePanelsBase extends React.Component {
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
             <Typography>
-              We are really sorry to hear that you want to delete your account. Please contact us at{' '}
-              <a
-                href="mailto:support@whichost.com?subject=Account Deletion Request"
-                target="_blank"
-              >
-                support@whichost.com
-              </a>{' '}
+              We are really sorry to hear that you want to delete your account. Please contact us{' '}
+              <NamedLink name="ContactUsPage">here</NamedLink>
               and we will assist you with the deletion.
             </Typography>
           </ExpansionPanelDetails>

--- a/src/containers/PayoutPreferencesPage/PayoutPreferencesPage.js
+++ b/src/containers/PayoutPreferencesPage/PayoutPreferencesPage.js
@@ -83,7 +83,7 @@ export const PayoutPreferencesPageComponent = props => {
 
 	} else if (currentUserLoaded && stripeConnected) {
 
-		const link = <NamedLink name="ContactUsPage" target="_blank">
+		const link = <NamedLink name="ContactUsPageEnquiry" params={{enquiry: "changePaymentInfo"}} target="_blank">
 			<FormattedMessage id="PayoutPreferencesPage.stripeAlreadyConnectedLink" />
 		</NamedLink>
 

--- a/src/forms/ContactUsForm/ContactUsForm.js
+++ b/src/forms/ContactUsForm/ContactUsForm.js
@@ -243,9 +243,9 @@ class ContactUsFormComponent extends Component {
             const termsAndConditionsRequiredMessage = intl.formatMessage({
               id: 'ContactUsForm.termsAndConditionsRequired',
             });
-						
-						const termsAndConditionsRequired = (values) => 
-							(values && values.length == 0)? termsAndConditionsRequiredMessage: null;	
+
+            const termsAndConditionsRequired = values =>
+              values && values.length == 0 ? termsAndConditionsRequiredMessage : null;
 
             // IBAN
 
@@ -392,7 +392,7 @@ class ContactUsFormComponent extends Component {
                     name="termsAndConditions"
                     id={formId ? `${formId}.termsAndConditions` : 'termsAndConditions'}
                     options={[{ key: 'agreed', label: 'I agree' }]}
-										validate={termsAndConditionsRequired}
+                    validate={termsAndConditionsRequired}
                   />
                   {pristine && !termsAndConditions && termsAndConditionsRequired}
                 </Fragment>
@@ -487,7 +487,10 @@ class ContactUsFormComponent extends Component {
                 key={formId}
                 className={classes}
                 onSubmit={e => {
-                  this.submittedValues = values;
+                  const valuesWithEmail = user.id
+                    ? { ...values, email: user.attributes.email }
+                    : values;
+                  this.submittedValues = valuesWithEmail;
                   handleSubmit(e);
                 }}
               >

--- a/src/forms/ContactUsForm/ContactUsForm.js
+++ b/src/forms/ContactUsForm/ContactUsForm.js
@@ -507,6 +507,7 @@ class ContactUsFormComponent extends Component {
                     <option value="booking">Booking a pub</option>
                     <option value="listing">Listing a space</option>
                     <option value="claim">Claiming a listing</option>
+                    <option value="privacy">Privacy Enquiry</option>
                     <option value="changePaymentInfo">Change payement informations</option>
                     <option value="corporate">Corporate Benefits Enquiries</option>
                   </FieldSelect>

--- a/src/routeConfiguration.js
+++ b/src/routeConfiguration.js
@@ -351,34 +351,9 @@ const routeConfiguration = () => {
       component: props => <ContactUsPage {...props} />,
     },
     {
-			path: '/contact-us/general',
-      name: 'ContactUsPage',
-      component: props => <ContactUsPage enquiry="general" {...props} />,
-    },
-    {
-			path: '/contact-us/booking',
-      name: 'ContactUsPage',
-      component: props => <ContactUsPage enquiry="booking" {...props} />,
-    },
-    {
-			path: '/contact-us/listing',
-      name: 'ContactUsPage',
-      component: props => <ContactUsPage enquiry="listing" {...props} />,
-    },
-    {
-			path: '/contact-us/claim',
-      name: 'ContactUsPage',
-      component: props => <ContactUsPage enquiry="claim" {...props} />,
-    },
-    {
-			path: '/contact-us/changePaymentInfo',
-      name: 'ContactUsPage',
-      component: props => <ContactUsPage enquiry="changePaymentInfo" {...props} />,
-    },
-    {
-			path: '/contact-us/corporate',
-      name: 'ContactUsPage',
-      component: props => <ContactUsPage enquiry="corporate" {...props} />,
+			path: '/contact-us/:enquiry',
+      name: 'ContactUsPageEnquiry',
+      component: props => <ContactUsPage {...props} />,
     },
     {
 			path: '/help/benefits',


### PR DESCRIPTION
**What have been done**: We changed the link of FAQ page and Privacy policy
**Pushed to**: `replace-link-to-contact-us-page`
**Tag somebody**: @Shane-Walsh 
**Issue**: #204  