### PR TITLE
Improve fee message in booking page

### DIFF
--- a/src/components/BookingBreakdown/BookingBreakdown.css
+++ b/src/components/BookingBreakdown/BookingBreakdown.css
@@ -102,7 +102,7 @@
 
 .feeInfo {
   @apply --marketplaceTinyFontStyles;
-  color: var(--matterColorAnti);
+  color: var(--attentionColor);
   margin: 0 0 20px 0;
   flex-shrink: 0;
 
@@ -112,7 +112,7 @@
   }
 
   @media (--viewportLarge) {
-    margin-top: 4px;
+    margin-top: 1.25em;
     margin-bottom: 22px;
   }
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -40,7 +40,7 @@
   "Avatar.bannedUserDisplayName": "Banned user",
   "BookingBreakdown.bookingPeriod": "{bookingStart}",
   "BookingBreakdown.commission": "Whichost fee *",
-  "BookingBreakdown.commissionFeeNote": "* The fee helps us run the platform and provide the best possible service to you!",
+  "BookingBreakdown.commissionFeeNote": "* 100% of the user fees are donated! They are consolidated every three months and donated to a local non-profit organisation.",
   "BookingBreakdown.dayCount": "{count, number} {count, plural, one {day} other {days}}",
   "BookingBreakdown.nightCount": "{count, number} {count, plural, one {night} other {nights}}",
   "BookingBreakdown.pricePerDay": "Price per day",


### PR DESCRIPTION
**What has been done**: Booking note text changed to: "100% of the user fees are donated! They are consolidated every three months and donated to a local non-profit organisation." Changed css of feeInfo class, with the font colour changed to dark blue, and the top margin changed to 1.25em. Now there is a line break between Total Cost and the Booking note,  and the booking note is changed to dark blue. 
**Pushed to**: improve-fee-message-in-booking-page
**Tag somebody**: @lcoenen @RohrerHope 

**Asking for validation**: 

- Check on mobile and on a desktop if the issue has been correctly fixed.
- If everything is correct, move the card to the accepted column.
- If the issue isn't fixed, re-open the comment clearly what the problem is and what is the desired result. 
- Move the card to have issues column.
- Merge (or express approval in) the corresponding PR if needed. Move the card to the launch column.