### PR TITLE
Clean Topbar logos on CheckOut Page - Staging #222

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/public/static/reactDates.css
+++ b/public/static/reactDates.css
@@ -4,6 +4,7 @@
 .PresetDateRangePicker_panel {
   padding: 0 22px 11px
 }
+
 .PresetDateRangePicker_button {
   position: relative;
   height: 100%;
@@ -21,33 +22,42 @@
   box-sizing: border-box;
   cursor: pointer
 }
+
 .PresetDateRangePicker_button:active {
   outline: 0
 }
+
 .PresetDateRangePicker_button__selected {
   color: #fff;
   background: #00a699
 }
+
 .SingleDatePickerInput {
   display: inline-block;
   background-color: #fff
 }
+
 .SingleDatePickerInput__withBorder {
   border-radius: 2px;
   border: 1px solid #dbdbdb
 }
+
 .SingleDatePickerInput__rtl {
   direction: rtl
 }
+
 .SingleDatePickerInput__disabled {
   background-color: #f2f2f2
 }
+
 .SingleDatePickerInput__block {
   display: block
 }
+
 .SingleDatePickerInput__showClearDate {
   padding-right: 30px
 }
+
 .SingleDatePickerInput_clearDate {
   background: 0 0;
   border: 0;
@@ -65,26 +75,32 @@
   -ms-transform: translateY(-50%);
   transform: translateY(-50%)
 }
+
 .SingleDatePickerInput_clearDate__default:focus,
 .SingleDatePickerInput_clearDate__default:hover {
   background: #dbdbdb;
   border-radius: 50%
 }
+
 .SingleDatePickerInput_clearDate__small {
   padding: 6px
 }
+
 .SingleDatePickerInput_clearDate__hide {
   visibility: hidden
 }
+
 .SingleDatePickerInput_clearDate_svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
   vertical-align: middle
 }
+
 .SingleDatePickerInput_clearDate_svg__small {
   height: 9px
 }
+
 .SingleDatePickerInput_calendarIcon {
   background: 0 0;
   border: 0;
@@ -98,44 +114,54 @@
   padding: 10px;
   margin: 0 5px 0 10px
 }
+
 .SingleDatePickerInput_calendarIcon_svg {
   fill: #82888a;
   height: 15px;
   width: 14px;
   vertical-align: middle
 }
+
 .SingleDatePicker {
   position: relative;
   display: inline-block
 }
+
 .SingleDatePicker__block {
   display: block
 }
+
 .SingleDatePicker_picker {
   z-index: 1;
   background-color: #fff;
   position: absolute
 }
+
 .SingleDatePicker_picker__rtl {
   direction: rtl
 }
+
 .SingleDatePicker_picker__directionLeft {
   left: 0
 }
+
 .SingleDatePicker_picker__directionRight {
   right: 0
 }
+
 .SingleDatePicker_picker__portal {
-  background-color: rgba(0,0,0,.3);
+  background-color: rgba(0, 0, 0, .3);
   position: fixed;
   top: 0;
   left: 0;
   height: 100%;
   width: 100%
 }
+
 .SingleDatePicker_picker__fullScreenPortal {
   background-color: #fff
 }
+
 .SingleDatePicker_closeButton {
   background: 0 0;
   border: 0;
@@ -150,16 +176,19 @@
   padding: 15px;
   z-index: 2
 }
+
 .SingleDatePicker_closeButton:focus,
 .SingleDatePicker_closeButton:hover {
-  color: darken(#cacccd,10%);
+  color: darken(#cacccd, 10%);
   text-decoration: none
 }
+
 .SingleDatePicker_closeButton_svg {
   height: 15px;
   width: 15px;
   fill: #cacccd
 }
+
 .DayPickerKeyboardShortcuts_buttonReset {
   background: 0 0;
   border: 0;
@@ -172,57 +201,70 @@
   cursor: pointer;
   font-size: 14px
 }
+
 .DayPickerKeyboardShortcuts_buttonReset:active {
   outline: 0
 }
+
 .DayPickerKeyboardShortcuts_show {
   width: 22px;
   position: absolute;
   z-index: 2
 }
+
 .DayPickerKeyboardShortcuts_show__bottomRight {
   border-top: 26px solid transparent;
   border-right: 33px solid #00a699;
   bottom: 0;
   right: 0
 }
+
 .DayPickerKeyboardShortcuts_show__bottomRight:hover {
   border-right: 33px solid #008489
 }
+
 .DayPickerKeyboardShortcuts_show__topRight {
   border-bottom: 26px solid transparent;
   border-right: 33px solid #00a699;
   top: 0;
   right: 0
 }
+
 .DayPickerKeyboardShortcuts_show__topRight:hover {
   border-right: 33px solid #008489
 }
+
 .DayPickerKeyboardShortcuts_show__topLeft {
   border-bottom: 26px solid transparent;
   border-left: 33px solid #00a699;
   top: 0;
   left: 0
 }
+
 .DayPickerKeyboardShortcuts_show__topLeft:hover {
   border-left: 33px solid #008489
 }
+
 .DayPickerKeyboardShortcuts_showSpan {
   color: #fff;
   position: absolute
 }
+
 .DayPickerKeyboardShortcuts_showSpan__bottomRight {
   bottom: 0;
   right: -28px
 }
+
 .DayPickerKeyboardShortcuts_showSpan__topRight {
   top: 1px;
   right: -28px
 }
+
 .DayPickerKeyboardShortcuts_showSpan__topLeft {
   top: 1px;
   left: -28px
 }
+
 .DayPickerKeyboardShortcuts_panel {
   overflow: auto;
   background: #fff;
@@ -237,34 +279,41 @@
   padding: 22px;
   margin: 33px
 }
+
 .DayPickerKeyboardShortcuts_title {
   font-size: 16px;
   font-weight: 700;
   margin: 0
 }
+
 .DayPickerKeyboardShortcuts_list {
   list-style: none;
   padding: 0;
   font-size: 14px
 }
+
 .DayPickerKeyboardShortcuts_close {
   position: absolute;
   right: 22px;
   top: 22px;
   z-index: 2
 }
+
 .DayPickerKeyboardShortcuts_close:active {
   outline: 0
 }
+
 .DayPickerKeyboardShortcuts_closeSvg {
   height: 15px;
   width: 15px;
   fill: #cacccd
 }
+
 .DayPickerKeyboardShortcuts_closeSvg:focus,
 .DayPickerKeyboardShortcuts_closeSvg:hover {
   fill: #82888a
 }
+
 .CalendarDay {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -272,68 +321,83 @@
   font-size: 14px;
   text-align: center
 }
+
 .CalendarDay:active {
   outline: 0
 }
+
 .CalendarDay__defaultCursor {
   cursor: default
 }
+
 .CalendarDay__default {
   border: 1px solid #e4e7e7;
   color: #484848;
   background: #fff
 }
+
 .CalendarDay__default:hover {
   background: #e4e7e7;
   border: 1px double #e4e7e7;
   color: inherit
 }
+
 .CalendarDay__hovered_offset {
   background: #f4f5f5;
   border: 1px double #e4e7e7;
   color: inherit
 }
+
 .CalendarDay__outside {
   border: 0;
   background: #fff;
   color: #484848
 }
+
 .CalendarDay__outside:hover {
   border: 0
 }
+
 .CalendarDay__blocked_minimum_nights {
   background: #fff;
   border: 1px solid #eceeee;
   color: #cacccd
 }
+
 .CalendarDay__blocked_minimum_nights:active,
 .CalendarDay__blocked_minimum_nights:hover {
   background: #fff;
   color: #cacccd
 }
+
 .CalendarDay__highlighted_calendar {
   background: #ffe8bc;
   color: #484848
 }
+
 .CalendarDay__highlighted_calendar:active,
 .CalendarDay__highlighted_calendar:hover {
   background: #ffce71;
   color: #484848
 }
+
 .CalendarDay__selected_span {
   background: #66e2da;
   border: 1px solid #33dacd;
   color: #fff
 }
+
 .CalendarDay__selected_span:active,
 .CalendarDay__selected_span:hover {
   background: #33dacd;
   border: 1px solid #33dacd;
   color: #fff
 }
+
 .CalendarDay__last_in_range {
   border-right: #00a699
 }
+
 .CalendarDay__selected,
 .CalendarDay__selected:active,
 .CalendarDay__selected:hover {
@@ -341,17 +405,20 @@
   border: 1px solid #00a699;
   color: #fff
 }
+
 .CalendarDay__hovered_span,
 .CalendarDay__hovered_span:hover {
   background: #b2f1ec;
   border: 1px solid #80e8e0;
   color: #007a87
 }
+
 .CalendarDay__hovered_span:active {
   background: #80e8e0;
   border: 1px solid #80e8e0;
   color: #007a87
 }
+
 .CalendarDay__blocked_calendar,
 .CalendarDay__blocked_calendar:active,
 .CalendarDay__blocked_calendar:hover {
@@ -359,6 +426,7 @@
   border: 1px solid #cacccd;
   color: #82888a
 }
+
 .CalendarDay__blocked_out_of_range,
 .CalendarDay__blocked_out_of_range:active,
 .CalendarDay__blocked_out_of_range:hover {
@@ -366,6 +434,7 @@
   border: 1px solid #e4e7e7;
   color: #cacccd
 }
+
 .CalendarMonth {
   background: #fff;
   text-align: center;
@@ -375,13 +444,17 @@
   -ms-user-select: none;
   user-select: none
 }
+
 .CalendarMonth_table {
   border-collapse: collapse;
-  border-spacing: 0
+  border-spacing: 0;
+  margin-top: 5px;
 }
+
 .CalendarMonth_verticalSpacing {
   border-collapse: separate
 }
+
 .CalendarMonth_caption {
   color: #484848;
   font-size: 18px;
@@ -390,50 +463,62 @@
   padding-bottom: 37px;
   caption-side: initial
 }
+
 .CalendarMonth_caption__verticalScrollable {
   padding-top: 12px;
   padding-bottom: 7px
 }
+
 .CalendarMonthGrid {
   background: #fff;
   text-align: left;
   z-index: 0
 }
+
 .CalendarMonthGrid__animating {
   z-index: 1
 }
+
 .CalendarMonthGrid__horizontal {
   position: absolute;
   left: 9px
 }
+
 .CalendarMonthGrid__vertical {
   margin: 0 auto
 }
+
 .CalendarMonthGrid__vertical_scrollable {
   margin: 0 auto;
   overflow-y: scroll
 }
+
 .CalendarMonthGrid_month__horizontal {
   display: inline-block;
   vertical-align: top;
   min-height: 100%
 }
+
 .CalendarMonthGrid_month__hideForAnimation {
   position: absolute;
   z-index: -1;
   opacity: 0;
   pointer-events: none
 }
+
 .CalendarMonthGrid_month__hidden {
   visibility: hidden
 }
+
 .DayPickerNavigation {
   position: relative;
   z-index: 2
 }
+
 .DayPickerNavigation__horizontal {
   height: 0
 }
+
 .DayPickerNavigation__verticalDefault {
   position: absolute;
   width: 100%;
@@ -441,9 +526,11 @@
   bottom: 0;
   left: 0
 }
+
 .DayPickerNavigation__verticalScrollableDefault {
   position: relative
 }
+
 .DayPickerNavigation_button {
   cursor: pointer;
   -webkit-user-select: none;
@@ -454,18 +541,22 @@
   padding: 0;
   margin: 0
 }
+
 .DayPickerNavigation_button__default {
   border: 1px solid #e4e7e7;
   background-color: #fff;
   color: #757575
 }
+
 .DayPickerNavigation_button__default:focus,
 .DayPickerNavigation_button__default:hover {
   border: 1px solid #c4c4c4
 }
+
 .DayPickerNavigation_button__default:active {
   background: #f2f2f2
 }
+
 .DayPickerNavigation_button__horizontalDefault {
   position: absolute;
   top: 18px;
@@ -473,80 +564,99 @@
   border-radius: 3px;
   padding: 6px 9px
 }
+
 .DayPickerNavigation_leftButton__horizontalDefault {
   left: 22px
 }
+
 .DayPickerNavigation_rightButton__horizontalDefault {
   right: 22px
 }
+
 .DayPickerNavigation_button__verticalDefault {
   padding: 5px;
   background: #fff;
-  box-shadow: 0 0 5px 2px rgba(0,0,0,.1);
+  box-shadow: 0 0 5px 2px rgba(0, 0, 0, .1);
   position: relative;
   display: inline-block;
   height: 100%;
   width: 50%
 }
+
 .DayPickerNavigation_nextButton__verticalDefault {
   border-left: 0
 }
+
 .DayPickerNavigation_nextButton__verticalScrollableDefault {
   width: 100%
 }
+
 .DayPickerNavigation_svg__horizontal {
   height: 19px;
   width: 19px;
   fill: #82888a;
   display: block
 }
+
 .DayPickerNavigation_svg__vertical {
   height: 42px;
   width: 42px;
   fill: #484848;
   display: block
 }
+
 .DayPicker {
   background: #fff;
   position: relative;
   text-align: left
 }
+
 .DayPicker__horizontal {
   background: #fff
 }
+
 .DayPicker__verticalScrollable {
   height: 100%
 }
+
 .DayPicker__hidden {
   visibility: hidden
 }
+
 .DayPicker__withBorder {
-  box-shadow: 0 2px 6px rgba(0,0,0,.05),0 0 0 1px rgba(0,0,0,.07);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, .05), 0 0 0 1px rgba(0, 0, 0, .07);
   border-radius: 3px
 }
+
 .DayPicker_portal__horizontal {
   box-shadow: none;
   position: absolute;
   left: 50%;
   top: 50%
 }
+
 .DayPicker_portal__vertical {
   position: initial
 }
+
 .DayPicker_focusRegion {
   outline: 0
 }
+
 .DayPicker_calendarInfo__horizontal,
 .DayPicker_wrapper__horizontal {
   display: inline-block;
   vertical-align: top
 }
+
 .DayPicker_weekHeaders {
   position: relative
 }
+
 .DayPicker_weekHeaders__horizontal {
   margin-left: 9px
 }
+
 .DayPicker_weekHeader {
   color: #757575;
   position: absolute;
@@ -554,9 +664,11 @@
   z-index: 2;
   text-align: left
 }
+
 .DayPicker_weekHeader__vertical {
   left: 50%
 }
+
 .DayPicker_weekHeader__verticalScrollable {
   top: 0;
   display: table-row;
@@ -567,6 +679,7 @@
   width: 100%;
   text-align: center
 }
+
 .DayPicker_weekHeader_ul {
   list-style: none;
   margin: 1px 0;
@@ -574,23 +687,28 @@
   padding-right: 0;
   font-size: 14px
 }
+
 .DayPicker_weekHeader_li {
   display: inline-block;
   text-align: center
 }
+
 .DayPicker_transitionContainer {
   position: relative;
   overflow: hidden;
   border-radius: 3px
 }
+
 .DayPicker_transitionContainer__horizontal {
   -webkit-transition: height .2s ease-in-out;
   -moz-transition: height .2s ease-in-out;
   transition: height .2s ease-in-out
 }
+
 .DayPicker_transitionContainer__vertical {
   width: 100%
 }
+
 .DayPicker_transitionContainer__verticalScrollable {
   padding-top: 20px;
   height: 100%;
@@ -601,6 +719,7 @@
   left: 0;
   overflow-y: scroll
 }
+
 .DateInput {
   margin: 0;
   padding: 0;
@@ -610,16 +729,20 @@
   width: 130px;
   vertical-align: middle
 }
+
 .DateInput__small {
   width: 97px
 }
+
 .DateInput__block {
   width: 100%
 }
+
 .DateInput__disabled {
   background: #f2f2f2;
   color: #dbdbdb
 }
+
 .DateInput_input {
   font-weight: 200;
   font-size: 19px;
@@ -635,21 +758,25 @@
   border-left: 0;
   border-radius: 0
 }
+
 .DateInput_input__small {
   font-size: 15px;
   line-height: 18px;
   letter-spacing: .2px;
   padding: 7px 7px 5px
 }
+
 .DateInput_input__regular {
   font-weight: auto
 }
+
 .DateInput_input__readOnly {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none
 }
+
 .DateInput_input__focused {
   outline: 0;
   background: #fff;
@@ -659,13 +786,15 @@
   border-bottom: 2px solid #008489;
   border-left: 0
 }
+
 .DateInput_input__disabled {
   background: #f2f2f2;
   font-style: italic
 }
+
 .DateInput_screenReaderMessage {
   border: 0;
-  clip: rect(0,0,0,0);
+  clip: rect(0, 0, 0, 0);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -673,6 +802,7 @@
   position: absolute;
   width: 1px
 }
+
 .DateInput_fang {
   position: absolute;
   width: 20px;
@@ -680,44 +810,55 @@
   left: 22px;
   z-index: 2
 }
+
 .DateInput_fangShape {
   fill: #fff
 }
+
 .DateInput_fangStroke {
   stroke: #dbdbdb;
   fill: transparent
 }
+
 .DateRangePickerInput {
   background-color: #fff;
   display: inline-block
 }
+
 .DateRangePickerInput__disabled {
   background: #f2f2f2
 }
+
 .DateRangePickerInput__withBorder {
   border-radius: 2px;
   border: 1px solid #dbdbdb
 }
+
 .DateRangePickerInput__rtl {
   direction: rtl
 }
+
 .DateRangePickerInput__block {
   display: block
 }
+
 .DateRangePickerInput__showClearDates {
   padding-right: 30px
 }
+
 .DateRangePickerInput_arrow {
   display: inline-block;
   vertical-align: middle;
   color: #484848
 }
+
 .DateRangePickerInput_arrow_svg {
   vertical-align: middle;
   fill: #484848;
   height: 24px;
   width: 24px
 }
+
 .DateRangePickerInput_clearDates {
   background: 0 0;
   border: 0;
@@ -735,26 +876,32 @@
   -ms-transform: translateY(-50%);
   transform: translateY(-50%)
 }
+
 .DateRangePickerInput_clearDates__small {
   padding: 6px
 }
+
 .DateRangePickerInput_clearDates_default:focus,
 .DateRangePickerInput_clearDates_default:hover {
   background: #dbdbdb;
   border-radius: 50%
 }
+
 .DateRangePickerInput_clearDates__hide {
   visibility: hidden
 }
+
 .DateRangePickerInput_clearDates_svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
   vertical-align: middle
 }
+
 .DateRangePickerInput_clearDates_svg__small {
   height: 9px
 }
+
 .DateRangePickerInput_calendarIcon {
   background: 0 0;
   border: 0;
@@ -768,44 +915,54 @@
   padding: 10px;
   margin: 0 5px 0 10px
 }
+
 .DateRangePickerInput_calendarIcon_svg {
   fill: #82888a;
   height: 15px;
   width: 14px;
   vertical-align: middle
 }
+
 .DateRangePicker {
   position: relative;
   display: inline-block
 }
+
 .DateRangePicker__block {
   display: block
 }
+
 .DateRangePicker_picker {
   z-index: 1;
   background-color: #fff;
   position: absolute
 }
+
 .DateRangePicker_picker__rtl {
   direction: rtl
 }
+
 .DateRangePicker_picker__directionLeft {
   left: 0
 }
+
 .DateRangePicker_picker__directionRight {
   right: 0
 }
+
 .DateRangePicker_picker__portal {
-  background-color: rgba(0,0,0,.3);
+  background-color: rgba(0, 0, 0, .3);
   position: fixed;
   top: 0;
   left: 0;
   height: 100%;
   width: 100%
 }
+
 .DateRangePicker_picker__fullScreenPortal {
   background-color: #fff
 }
+
 .DateRangePicker_closeButton {
   background: 0 0;
   border: 0;
@@ -820,11 +977,13 @@
   padding: 15px;
   z-index: 2
 }
+
 .DateRangePicker_closeButton:focus,
 .DateRangePicker_closeButton:hover {
-  color: darken(#cacccd,10%);
+  color: darken(#cacccd, 10%);
   text-decoration: none
 }
+
 .DateRangePicker_closeButton_svg {
   height: 15px;
   width: 15px;

--- a/public/static/reactDates.css
+++ b/public/static/reactDates.css
@@ -4,7 +4,6 @@
 .PresetDateRangePicker_panel {
   padding: 0 22px 11px
 }
-
 .PresetDateRangePicker_button {
   position: relative;
   height: 100%;
@@ -22,42 +21,33 @@
   box-sizing: border-box;
   cursor: pointer
 }
-
 .PresetDateRangePicker_button:active {
   outline: 0
 }
-
 .PresetDateRangePicker_button__selected {
   color: #fff;
   background: #00a699
 }
-
 .SingleDatePickerInput {
   display: inline-block;
   background-color: #fff
 }
-
 .SingleDatePickerInput__withBorder {
   border-radius: 2px;
   border: 1px solid #dbdbdb
 }
-
 .SingleDatePickerInput__rtl {
   direction: rtl
 }
-
 .SingleDatePickerInput__disabled {
   background-color: #f2f2f2
 }
-
 .SingleDatePickerInput__block {
   display: block
 }
-
 .SingleDatePickerInput__showClearDate {
   padding-right: 30px
 }
-
 .SingleDatePickerInput_clearDate {
   background: 0 0;
   border: 0;
@@ -75,32 +65,26 @@
   -ms-transform: translateY(-50%);
   transform: translateY(-50%)
 }
-
 .SingleDatePickerInput_clearDate__default:focus,
 .SingleDatePickerInput_clearDate__default:hover {
   background: #dbdbdb;
   border-radius: 50%
 }
-
 .SingleDatePickerInput_clearDate__small {
   padding: 6px
 }
-
 .SingleDatePickerInput_clearDate__hide {
   visibility: hidden
 }
-
 .SingleDatePickerInput_clearDate_svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
   vertical-align: middle
 }
-
 .SingleDatePickerInput_clearDate_svg__small {
   height: 9px
 }
-
 .SingleDatePickerInput_calendarIcon {
   background: 0 0;
   border: 0;
@@ -114,41 +98,33 @@
   padding: 10px;
   margin: 0 5px 0 10px
 }
-
 .SingleDatePickerInput_calendarIcon_svg {
   fill: #82888a;
   height: 15px;
   width: 14px;
   vertical-align: middle
 }
-
 .SingleDatePicker {
   position: relative;
   display: inline-block
 }
-
 .SingleDatePicker__block {
   display: block
 }
-
 .SingleDatePicker_picker {
   z-index: 1;
   background-color: #fff;
   position: absolute
 }
-
 .SingleDatePicker_picker__rtl {
   direction: rtl
 }
-
 .SingleDatePicker_picker__directionLeft {
   left: 0
 }
-
 .SingleDatePicker_picker__directionRight {
   right: 0
 }
-
 .SingleDatePicker_picker__portal {
   background-color: rgba(0, 0, 0, .3);
   position: fixed;
@@ -157,11 +133,9 @@
   height: 100%;
   width: 100%
 }
-
 .SingleDatePicker_picker__fullScreenPortal {
   background-color: #fff
 }
-
 .SingleDatePicker_closeButton {
   background: 0 0;
   border: 0;
@@ -176,19 +150,16 @@
   padding: 15px;
   z-index: 2
 }
-
 .SingleDatePicker_closeButton:focus,
 .SingleDatePicker_closeButton:hover {
   color: darken(#cacccd, 10%);
   text-decoration: none
 }
-
 .SingleDatePicker_closeButton_svg {
   height: 15px;
   width: 15px;
   fill: #cacccd
 }
-
 .DayPickerKeyboardShortcuts_buttonReset {
   background: 0 0;
   border: 0;
@@ -201,70 +172,57 @@
   cursor: pointer;
   font-size: 14px
 }
-
 .DayPickerKeyboardShortcuts_buttonReset:active {
   outline: 0
 }
-
 .DayPickerKeyboardShortcuts_show {
   width: 22px;
   position: absolute;
   z-index: 2
 }
-
 .DayPickerKeyboardShortcuts_show__bottomRight {
   border-top: 26px solid transparent;
   border-right: 33px solid #00a699;
   bottom: 0;
   right: 0
 }
-
 .DayPickerKeyboardShortcuts_show__bottomRight:hover {
   border-right: 33px solid #008489
 }
-
 .DayPickerKeyboardShortcuts_show__topRight {
   border-bottom: 26px solid transparent;
   border-right: 33px solid #00a699;
   top: 0;
   right: 0
 }
-
 .DayPickerKeyboardShortcuts_show__topRight:hover {
   border-right: 33px solid #008489
 }
-
 .DayPickerKeyboardShortcuts_show__topLeft {
   border-bottom: 26px solid transparent;
   border-left: 33px solid #00a699;
   top: 0;
   left: 0
 }
-
 .DayPickerKeyboardShortcuts_show__topLeft:hover {
   border-left: 33px solid #008489
 }
-
 .DayPickerKeyboardShortcuts_showSpan {
   color: #fff;
   position: absolute
 }
-
 .DayPickerKeyboardShortcuts_showSpan__bottomRight {
   bottom: 0;
   right: -28px
 }
-
 .DayPickerKeyboardShortcuts_showSpan__topRight {
   top: 1px;
   right: -28px
 }
-
 .DayPickerKeyboardShortcuts_showSpan__topLeft {
   top: 1px;
   left: -28px
 }
-
 .DayPickerKeyboardShortcuts_panel {
   overflow: auto;
   background: #fff;
@@ -279,41 +237,34 @@
   padding: 22px;
   margin: 33px
 }
-
 .DayPickerKeyboardShortcuts_title {
   font-size: 16px;
   font-weight: 700;
   margin: 0
 }
-
 .DayPickerKeyboardShortcuts_list {
   list-style: none;
   padding: 0;
   font-size: 14px
 }
-
 .DayPickerKeyboardShortcuts_close {
   position: absolute;
   right: 22px;
   top: 22px;
   z-index: 2
 }
-
 .DayPickerKeyboardShortcuts_close:active {
   outline: 0
 }
-
 .DayPickerKeyboardShortcuts_closeSvg {
   height: 15px;
   width: 15px;
   fill: #cacccd
 }
-
 .DayPickerKeyboardShortcuts_closeSvg:focus,
 .DayPickerKeyboardShortcuts_closeSvg:hover {
   fill: #82888a
 }
-
 .CalendarDay {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -321,83 +272,68 @@
   font-size: 14px;
   text-align: center
 }
-
 .CalendarDay:active {
   outline: 0
 }
-
 .CalendarDay__defaultCursor {
   cursor: default
 }
-
 .CalendarDay__default {
   border: 1px solid #e4e7e7;
   color: #484848;
   background: #fff
 }
-
 .CalendarDay__default:hover {
   background: #e4e7e7;
   border: 1px double #e4e7e7;
   color: inherit
 }
-
 .CalendarDay__hovered_offset {
   background: #f4f5f5;
   border: 1px double #e4e7e7;
   color: inherit
 }
-
 .CalendarDay__outside {
   border: 0;
   background: #fff;
   color: #484848
 }
-
 .CalendarDay__outside:hover {
   border: 0
 }
-
 .CalendarDay__blocked_minimum_nights {
   background: #fff;
   border: 1px solid #eceeee;
   color: #cacccd
 }
-
 .CalendarDay__blocked_minimum_nights:active,
 .CalendarDay__blocked_minimum_nights:hover {
   background: #fff;
   color: #cacccd
 }
-
 .CalendarDay__highlighted_calendar {
   background: #ffe8bc;
   color: #484848
 }
-
 .CalendarDay__highlighted_calendar:active,
 .CalendarDay__highlighted_calendar:hover {
   background: #ffce71;
   color: #484848
 }
-
 .CalendarDay__selected_span {
   background: #66e2da;
   border: 1px solid #33dacd;
   color: #fff
 }
-
 .CalendarDay__selected_span:active,
 .CalendarDay__selected_span:hover {
   background: #33dacd;
   border: 1px solid #33dacd;
   color: #fff
 }
-
 .CalendarDay__last_in_range {
   border-right: #00a699
 }
-
 .CalendarDay__selected,
 .CalendarDay__selected:active,
 .CalendarDay__selected:hover {
@@ -405,20 +341,17 @@
   border: 1px solid #00a699;
   color: #fff
 }
-
 .CalendarDay__hovered_span,
 .CalendarDay__hovered_span:hover {
   background: #b2f1ec;
   border: 1px solid #80e8e0;
   color: #007a87
 }
-
 .CalendarDay__hovered_span:active {
   background: #80e8e0;
   border: 1px solid #80e8e0;
   color: #007a87
 }
-
 .CalendarDay__blocked_calendar,
 .CalendarDay__blocked_calendar:active,
 .CalendarDay__blocked_calendar:hover {
@@ -426,7 +359,6 @@
   border: 1px solid #cacccd;
   color: #82888a
 }
-
 .CalendarDay__blocked_out_of_range,
 .CalendarDay__blocked_out_of_range:active,
 .CalendarDay__blocked_out_of_range:hover {
@@ -434,7 +366,6 @@
   border: 1px solid #e4e7e7;
   color: #cacccd
 }
-
 .CalendarMonth {
   background: #fff;
   text-align: center;
@@ -444,17 +375,14 @@
   -ms-user-select: none;
   user-select: none
 }
-
 .CalendarMonth_table {
   border-collapse: collapse;
   border-spacing: 0;
   margin-top: 5px;
 }
-
 .CalendarMonth_verticalSpacing {
   border-collapse: separate
 }
-
 .CalendarMonth_caption {
   color: #484848;
   font-size: 18px;
@@ -463,62 +391,50 @@
   padding-bottom: 37px;
   caption-side: initial
 }
-
 .CalendarMonth_caption__verticalScrollable {
   padding-top: 12px;
   padding-bottom: 7px
 }
-
 .CalendarMonthGrid {
   background: #fff;
   text-align: left;
   z-index: 0
 }
-
 .CalendarMonthGrid__animating {
   z-index: 1
 }
-
 .CalendarMonthGrid__horizontal {
   position: absolute;
   left: 9px
 }
-
 .CalendarMonthGrid__vertical {
   margin: 0 auto
 }
-
 .CalendarMonthGrid__vertical_scrollable {
   margin: 0 auto;
   overflow-y: scroll
 }
-
 .CalendarMonthGrid_month__horizontal {
   display: inline-block;
   vertical-align: top;
   min-height: 100%
 }
-
 .CalendarMonthGrid_month__hideForAnimation {
   position: absolute;
   z-index: -1;
   opacity: 0;
   pointer-events: none
 }
-
 .CalendarMonthGrid_month__hidden {
   visibility: hidden
 }
-
 .DayPickerNavigation {
   position: relative;
   z-index: 2
 }
-
 .DayPickerNavigation__horizontal {
   height: 0
 }
-
 .DayPickerNavigation__verticalDefault {
   position: absolute;
   width: 100%;
@@ -526,11 +442,9 @@
   bottom: 0;
   left: 0
 }
-
 .DayPickerNavigation__verticalScrollableDefault {
   position: relative
 }
-
 .DayPickerNavigation_button {
   cursor: pointer;
   -webkit-user-select: none;
@@ -541,22 +455,18 @@
   padding: 0;
   margin: 0
 }
-
 .DayPickerNavigation_button__default {
   border: 1px solid #e4e7e7;
   background-color: #fff;
   color: #757575
 }
-
 .DayPickerNavigation_button__default:focus,
 .DayPickerNavigation_button__default:hover {
   border: 1px solid #c4c4c4
 }
-
 .DayPickerNavigation_button__default:active {
   background: #f2f2f2
 }
-
 .DayPickerNavigation_button__horizontalDefault {
   position: absolute;
   top: 18px;
@@ -564,15 +474,12 @@
   border-radius: 3px;
   padding: 6px 9px
 }
-
 .DayPickerNavigation_leftButton__horizontalDefault {
   left: 22px
 }
-
 .DayPickerNavigation_rightButton__horizontalDefault {
   right: 22px
 }
-
 .DayPickerNavigation_button__verticalDefault {
   padding: 5px;
   background: #fff;
@@ -582,81 +489,65 @@
   height: 100%;
   width: 50%
 }
-
 .DayPickerNavigation_nextButton__verticalDefault {
   border-left: 0
 }
-
 .DayPickerNavigation_nextButton__verticalScrollableDefault {
   width: 100%
 }
-
 .DayPickerNavigation_svg__horizontal {
   height: 19px;
   width: 19px;
   fill: #82888a;
   display: block
 }
-
 .DayPickerNavigation_svg__vertical {
   height: 42px;
   width: 42px;
   fill: #484848;
   display: block
 }
-
 .DayPicker {
   background: #fff;
   position: relative;
   text-align: left
 }
-
 .DayPicker__horizontal {
   background: #fff
 }
-
 .DayPicker__verticalScrollable {
   height: 100%
 }
-
 .DayPicker__hidden {
   visibility: hidden
 }
-
 .DayPicker__withBorder {
   box-shadow: 0 2px 6px rgba(0, 0, 0, .05), 0 0 0 1px rgba(0, 0, 0, .07);
   border-radius: 3px
 }
-
 .DayPicker_portal__horizontal {
   box-shadow: none;
   position: absolute;
   left: 50%;
   top: 50%
 }
-
 .DayPicker_portal__vertical {
   position: initial
 }
-
 .DayPicker_focusRegion {
   outline: 0
 }
-
 .DayPicker_calendarInfo__horizontal,
 .DayPicker_wrapper__horizontal {
   display: inline-block;
   vertical-align: top
 }
-
 .DayPicker_weekHeaders {
   position: relative
 }
-
 .DayPicker_weekHeaders__horizontal {
   margin-left: 9px
 }
-
 .DayPicker_weekHeader {
   color: #757575;
   position: absolute;
@@ -664,11 +555,9 @@
   z-index: 2;
   text-align: left
 }
-
 .DayPicker_weekHeader__vertical {
   left: 50%
 }
-
 .DayPicker_weekHeader__verticalScrollable {
   top: 0;
   display: table-row;
@@ -679,7 +568,6 @@
   width: 100%;
   text-align: center
 }
-
 .DayPicker_weekHeader_ul {
   list-style: none;
   margin: 1px 0;
@@ -687,28 +575,23 @@
   padding-right: 0;
   font-size: 14px
 }
-
 .DayPicker_weekHeader_li {
   display: inline-block;
   text-align: center
 }
-
 .DayPicker_transitionContainer {
   position: relative;
   overflow: hidden;
   border-radius: 3px
 }
-
 .DayPicker_transitionContainer__horizontal {
   -webkit-transition: height .2s ease-in-out;
   -moz-transition: height .2s ease-in-out;
   transition: height .2s ease-in-out
 }
-
 .DayPicker_transitionContainer__vertical {
   width: 100%
 }
-
 .DayPicker_transitionContainer__verticalScrollable {
   padding-top: 20px;
   height: 100%;
@@ -719,7 +602,6 @@
   left: 0;
   overflow-y: scroll
 }
-
 .DateInput {
   margin: 0;
   padding: 0;
@@ -729,20 +611,16 @@
   width: 130px;
   vertical-align: middle
 }
-
 .DateInput__small {
   width: 97px
 }
-
 .DateInput__block {
   width: 100%
 }
-
 .DateInput__disabled {
   background: #f2f2f2;
   color: #dbdbdb
 }
-
 .DateInput_input {
   font-weight: 200;
   font-size: 19px;
@@ -758,25 +636,21 @@
   border-left: 0;
   border-radius: 0
 }
-
 .DateInput_input__small {
   font-size: 15px;
   line-height: 18px;
   letter-spacing: .2px;
   padding: 7px 7px 5px
 }
-
 .DateInput_input__regular {
   font-weight: auto
 }
-
 .DateInput_input__readOnly {
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none
 }
-
 .DateInput_input__focused {
   outline: 0;
   background: #fff;
@@ -786,12 +660,10 @@
   border-bottom: 2px solid #008489;
   border-left: 0
 }
-
 .DateInput_input__disabled {
   background: #f2f2f2;
   font-style: italic
 }
-
 .DateInput_screenReaderMessage {
   border: 0;
   clip: rect(0, 0, 0, 0);
@@ -802,7 +674,6 @@
   position: absolute;
   width: 1px
 }
-
 .DateInput_fang {
   position: absolute;
   width: 20px;
@@ -810,55 +681,44 @@
   left: 22px;
   z-index: 2
 }
-
 .DateInput_fangShape {
   fill: #fff
 }
-
 .DateInput_fangStroke {
   stroke: #dbdbdb;
   fill: transparent
 }
-
 .DateRangePickerInput {
   background-color: #fff;
   display: inline-block
 }
-
 .DateRangePickerInput__disabled {
   background: #f2f2f2
 }
-
 .DateRangePickerInput__withBorder {
   border-radius: 2px;
   border: 1px solid #dbdbdb
 }
-
 .DateRangePickerInput__rtl {
   direction: rtl
 }
-
 .DateRangePickerInput__block {
   display: block
 }
-
 .DateRangePickerInput__showClearDates {
   padding-right: 30px
 }
-
 .DateRangePickerInput_arrow {
   display: inline-block;
   vertical-align: middle;
   color: #484848
 }
-
 .DateRangePickerInput_arrow_svg {
   vertical-align: middle;
   fill: #484848;
   height: 24px;
   width: 24px
 }
-
 .DateRangePickerInput_clearDates {
   background: 0 0;
   border: 0;
@@ -876,32 +736,26 @@
   -ms-transform: translateY(-50%);
   transform: translateY(-50%)
 }
-
 .DateRangePickerInput_clearDates__small {
   padding: 6px
 }
-
 .DateRangePickerInput_clearDates_default:focus,
 .DateRangePickerInput_clearDates_default:hover {
   background: #dbdbdb;
   border-radius: 50%
 }
-
 .DateRangePickerInput_clearDates__hide {
   visibility: hidden
 }
-
 .DateRangePickerInput_clearDates_svg {
   fill: #82888a;
   height: 12px;
   width: 15px;
   vertical-align: middle
 }
-
 .DateRangePickerInput_clearDates_svg__small {
   height: 9px
 }
-
 .DateRangePickerInput_calendarIcon {
   background: 0 0;
   border: 0;
@@ -915,41 +769,33 @@
   padding: 10px;
   margin: 0 5px 0 10px
 }
-
 .DateRangePickerInput_calendarIcon_svg {
   fill: #82888a;
   height: 15px;
   width: 14px;
   vertical-align: middle
 }
-
 .DateRangePicker {
   position: relative;
   display: inline-block
 }
-
 .DateRangePicker__block {
   display: block
 }
-
 .DateRangePicker_picker {
   z-index: 1;
   background-color: #fff;
   position: absolute
 }
-
 .DateRangePicker_picker__rtl {
   direction: rtl
 }
-
 .DateRangePicker_picker__directionLeft {
   left: 0
 }
-
 .DateRangePicker_picker__directionRight {
   right: 0
 }
-
 .DateRangePicker_picker__portal {
   background-color: rgba(0, 0, 0, .3);
   position: fixed;
@@ -958,11 +804,9 @@
   height: 100%;
   width: 100%
 }
-
 .DateRangePicker_picker__fullScreenPortal {
   background-color: #fff
 }
-
 .DateRangePicker_closeButton {
   background: 0 0;
   border: 0;
@@ -977,13 +821,11 @@
   padding: 15px;
   z-index: 2
 }
-
 .DateRangePicker_closeButton:focus,
 .DateRangePicker_closeButton:hover {
   color: darken(#cacccd, 10%);
   text-decoration: none
 }
-
 .DateRangePicker_closeButton_svg {
   height: 15px;
   width: 15px;

--- a/public/static/reactDates.css
+++ b/public/static/reactDates.css
@@ -126,7 +126,7 @@
   right: 0
 }
 .SingleDatePicker_picker__portal {
-  background-color: rgba(0, 0, 0, .3);
+  background-color: rgba(0,0,0,.3);
   position: fixed;
   top: 0;
   left: 0;
@@ -152,7 +152,7 @@
 }
 .SingleDatePicker_closeButton:focus,
 .SingleDatePicker_closeButton:hover {
-  color: darken(#cacccd, 10%);
+  color: darken(#cacccd,10%);
   text-decoration: none
 }
 .SingleDatePicker_closeButton_svg {
@@ -483,7 +483,7 @@
 .DayPickerNavigation_button__verticalDefault {
   padding: 5px;
   background: #fff;
-  box-shadow: 0 0 5px 2px rgba(0, 0, 0, .1);
+  box-shadow: 0 0 5px 2px rgba(0,0,0,.1);
   position: relative;
   display: inline-block;
   height: 100%;
@@ -522,7 +522,7 @@
   visibility: hidden
 }
 .DayPicker__withBorder {
-  box-shadow: 0 2px 6px rgba(0, 0, 0, .05), 0 0 0 1px rgba(0, 0, 0, .07);
+  box-shadow: 0 2px 6px rgba(0,0,0,.05),0 0 0 1px rgba(0,0,0,.07);
   border-radius: 3px
 }
 .DayPicker_portal__horizontal {
@@ -666,7 +666,7 @@
 }
 .DateInput_screenReaderMessage {
   border: 0;
-  clip: rect(0, 0, 0, 0);
+  clip: rect(0,0,0,0);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -797,7 +797,7 @@
   right: 0
 }
 .DateRangePicker_picker__portal {
-  background-color: rgba(0, 0, 0, .3);
+  background-color: rgba(0,0,0,.3);
   position: fixed;
   top: 0;
   left: 0;
@@ -823,7 +823,7 @@
 }
 .DateRangePicker_closeButton:focus,
 .DateRangePicker_closeButton:hover {
-  color: darken(#cacccd, 10%);
+  color: darken(#cacccd,10%);
   text-decoration: none
 }
 .DateRangePicker_closeButton_svg {

--- a/src/components/CookieConsent/CookieConsent.js
+++ b/src/components/CookieConsent/CookieConsent.js
@@ -47,7 +47,7 @@ class CookieConsent extends Component {
       return null;
     } else {
       const cookieLink = (
-				<ExternalLink href="https://info.whichost.com/eng/legal#cookies-section" className={css.cookieLink}>
+				<ExternalLink href="https://www.whichost.com/legal/privacy-policy" className={css.cookieLink}>
           <FormattedMessage id="CookieConsent.cookieLink" />
         </ExternalLink>
       );

--- a/src/components/FieldDateInput/DateInput.css
+++ b/src/components/FieldDateInput/DateInput.css
@@ -26,6 +26,7 @@
   & :global(.SingleDatePicker) {
     display: block;
   }
+
   & :global(.SingleDatePicker_picker__directionLeft) {
     /* !important is added to top because react-dates uses inline style for height */
     /* Similar problem as in issue: https://github.com/airbnb/react-dates/issues/947 */
@@ -59,6 +60,7 @@
       border-bottom-width: 3px;
     }
   }
+
   & :global(.SingleDatePickerInput) {
     width: 100%;
     display: flex;
@@ -66,6 +68,7 @@
     border: none;
     background: none;
   }
+
   & :global(.DayPicker__horizontal) {
     margin: 0 auto;
     background-color: var(--marketplaceColor);
@@ -102,10 +105,12 @@
   & :global(.CalendarMonthGrid) {
     background-color: transparent;
   }
+
   & :global(.DateInput) {
     display: block;
     width: 100%;
   }
+
   & :global(.DayPicker_weekHeader) {
     color: var(--matterColorLight);
     top: 57px;
@@ -134,12 +139,14 @@
     width: 100%;
     height: 100%;
   }
+
   & :global(.CalendarDay) {
     @apply --marketplaceH4FontStyles;
     color: var(--matterColorLight);
     border: 0;
     margin-top: 0;
     margin-bottom: 0;
+    padding: 0 !important;
 
     @media (--viewportMedium) {
       margin-top: 0;
@@ -164,6 +171,7 @@
     background-image: transparent;
     background-color: transparent;
   }
+
   & :global(.CalendarDay__hovered_span .renderedDay) {
     display: flex;
     justify-content: center;
@@ -172,6 +180,7 @@
     height: var(--DateInput_selectionHeight);
     background-color: var(--DateInput_hoveredOverlayColor);
   }
+
   & :global(.CalendarDay__selected_span .renderedDay) {
     display: flex;
     justify-content: center;
@@ -181,11 +190,13 @@
     background-color: var(--successColor);
     transition: all 0.2s ease-out;
   }
+
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__selected) {
     background-color: transparent;
     background-image: none;
   }
+
   & :global(.CalendarDay__selected .renderedDay) {
     display: flex;
     justify-content: center;
@@ -195,10 +206,12 @@
     background-color: var(--successColor);
     border-radius: calc(var(--DateInput_selectionHeight) / 2);
   }
+
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__after-hovered) {
     background-color: transparent;
   }
+
   & :global(.CalendarDay__after-hovered .renderedDay) {
     display: flex;
     justify-content: center;
@@ -207,6 +220,7 @@
     height: var(--DateInput_selectionHeight);
     background-color: var(--DateInput_hoveredOverlayColor);
   }
+
   & :global(.CalendarDay:hover .renderedDay) {
     display: flex;
     justify-content: center;
@@ -215,6 +229,7 @@
     height: var(--DateInput_selectionHeight);
     background-color: var(--DateInput_hoveredOverlayColor);
   }
+
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__blocked_out_of_range),
   & :global(.CalendarDay__blocked_out_of_range:active),
@@ -223,6 +238,7 @@
     color: var(--marketplaceColorDark);
     border: 0;
   }
+
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__blocked_calendar),
   & :global(.CalendarDay__blocked_calendar:active),
@@ -231,12 +247,15 @@
     color: var(--marketplaceColorDark);
     border: 0;
   }
+
   & :global(.CalendarDay__blocked_out_of_range .CalendarDay__blocked_calendar .renderedDay) {
     background-color: transparent;
   }
+
   & :global(.DateInput_fang) {
     display: none;
   }
+
   & :global(.CalendarMonth_caption) {
     text-transform: capitalize;
   }

--- a/src/components/FieldDateInput/DateInput.css
+++ b/src/components/FieldDateInput/DateInput.css
@@ -26,7 +26,6 @@
   & :global(.SingleDatePicker) {
     display: block;
   }
-
   & :global(.SingleDatePicker_picker__directionLeft) {
     /* !important is added to top because react-dates uses inline style for height */
     /* Similar problem as in issue: https://github.com/airbnb/react-dates/issues/947 */
@@ -60,7 +59,6 @@
       border-bottom-width: 3px;
     }
   }
-
   & :global(.SingleDatePickerInput) {
     width: 100%;
     display: flex;
@@ -68,7 +66,6 @@
     border: none;
     background: none;
   }
-
   & :global(.DayPicker__horizontal) {
     margin: 0 auto;
     background-color: var(--marketplaceColor);
@@ -105,12 +102,10 @@
   & :global(.CalendarMonthGrid) {
     background-color: transparent;
   }
-
   & :global(.DateInput) {
     display: block;
     width: 100%;
   }
-
   & :global(.DayPicker_weekHeader) {
     color: var(--matterColorLight);
     top: 57px;
@@ -139,7 +134,6 @@
     width: 100%;
     height: 100%;
   }
-
   & :global(.CalendarDay) {
     @apply --marketplaceH4FontStyles;
     color: var(--matterColorLight);
@@ -171,7 +165,6 @@
     background-image: transparent;
     background-color: transparent;
   }
-
   & :global(.CalendarDay__hovered_span .renderedDay) {
     display: flex;
     justify-content: center;
@@ -180,7 +173,6 @@
     height: var(--DateInput_selectionHeight);
     background-color: var(--DateInput_hoveredOverlayColor);
   }
-
   & :global(.CalendarDay__selected_span .renderedDay) {
     display: flex;
     justify-content: center;
@@ -190,13 +182,11 @@
     background-color: var(--successColor);
     transition: all 0.2s ease-out;
   }
-
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__selected) {
     background-color: transparent;
     background-image: none;
   }
-
   & :global(.CalendarDay__selected .renderedDay) {
     display: flex;
     justify-content: center;
@@ -206,12 +196,10 @@
     background-color: var(--successColor);
     border-radius: calc(var(--DateInput_selectionHeight) / 2);
   }
-
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__after-hovered) {
     background-color: transparent;
   }
-
   & :global(.CalendarDay__after-hovered .renderedDay) {
     display: flex;
     justify-content: center;
@@ -220,7 +208,6 @@
     height: var(--DateInput_selectionHeight);
     background-color: var(--DateInput_hoveredOverlayColor);
   }
-
   & :global(.CalendarDay:hover .renderedDay) {
     display: flex;
     justify-content: center;
@@ -229,7 +216,6 @@
     height: var(--DateInput_selectionHeight);
     background-color: var(--DateInput_hoveredOverlayColor);
   }
-
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__blocked_out_of_range),
   & :global(.CalendarDay__blocked_out_of_range:active),
@@ -238,7 +224,6 @@
     color: var(--marketplaceColorDark);
     border: 0;
   }
-
   /* Remove default bg-color and use our extra span instead '.renderedDay' */
   & :global(.CalendarDay__blocked_calendar),
   & :global(.CalendarDay__blocked_calendar:active),
@@ -247,15 +232,12 @@
     color: var(--marketplaceColorDark);
     border: 0;
   }
-
   & :global(.CalendarDay__blocked_out_of_range .CalendarDay__blocked_calendar .renderedDay) {
     background-color: transparent;
   }
-
   & :global(.DateInput_fang) {
     display: none;
   }
-
   & :global(.CalendarMonth_caption) {
     text-transform: capitalize;
   }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -299,7 +299,7 @@
   "EditListingWizard.tabLabelDescription": "Description",
   "EditListingWizard.tabLabelCapacity": "Capacity",
   "EditListingWizard.tabLabelRegularlyOpenOn": "Opening days",
-  "EditListingWizard.saveNewPricing": "Next: Availability",
+  "EditListingWizard.saveNewPricing": "Next: Photos",
   "EditListingWizard.tabLabelFeatures": "Amenities",
   "EditListingWizard.tabLabelAvailability": "Availability",
   "EditListingWizard.tabLabelLocation": "Location",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -441,6 +441,8 @@
   "LegalsPages.communityGuidelinesTabTitle": "Community Guidelines",
 
   "ListingCard.hostedBy": "Hosted by {authorName}.",
+  "ListingCard.commonSpace": "Common space",
+  "ListingCard.privateSpace": "Private space",
   "ListingCard.unsupportedPrice": "({currency})",
   "ListingCard.unsupportedPriceTitle": "Unsupported currency ({currency})",
   "ListingPage.bookingSubTitle": "Start by choosing your dates.",


### PR DESCRIPTION
**Topbar Mobile Logo**

Mobile logo would not respond to CSS on CheckOutPage, so as a fix for now the desktop logo is displayed on the TopBar. 

![#222](https://user-images.githubusercontent.com/20372577/59219274-fceb4b00-8bb9-11e9-8969-b460b8be7ab9.png)

**New Logos**

All these logos will be replaced with the new logo set soon. So, I will have another look at this issue at that point
