### PR TITLE
Reviews now display on right and bottom of listing

### DIFF
--- a/src/components/BookingPanel/BookingPanel.css
+++ b/src/components/BookingPanel/BookingPanel.css
@@ -205,10 +205,11 @@
 }
 
 .reviewWrap {
-  margin: 40px 0 40px 20px;
+  display: none;
 }
 @media(min-width: 768px){
   .reviewWrap {
     margin: 40px 0 40px 0px;
+    display: block;
   }
 }

--- a/src/components/BookingPanel/BookingPanel.js
+++ b/src/components/BookingPanel/BookingPanel.js
@@ -5,8 +5,9 @@ import React from 'react';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
-import { Button, ModalInMobile, Reviews } from '../../components';
+import { Button, ModalInMobile } from '../../components';
 import config from '../../config';
+import SectionReview from '../../containers/ListingPage/SectionReviews';
 import { BookingDatesForm } from '../../forms';
 import { formatMoney } from '../../util/currency';
 import { LISTING_STATE_CLOSED, propTypes } from '../../util/types';
@@ -149,8 +150,7 @@ const BookingPanel = props => {
         )}
       </div>
       <div className={css.reviewWrap}>
-        {fetchReviewsError ? reviewsError : null}
-        <Reviews reviews={reviews} />
+        <SectionReview reviews={reviews} />
       </div>
     </div>
   );

--- a/src/components/Reviews/Reviews.js
+++ b/src/components/Reviews/Reviews.js
@@ -49,15 +49,8 @@ const ReviewsComponent = props => {
   const { className, rootClassName, reviews, intl } = props;
   const classes = classNames(rootClassName || css.root, className);
 
-  const reviewCount = reviews.length ? (
-    <div className={css.reviewCountLable}>Reviews ({reviews.length})</div>
-  ) : (
-    ''
-  );
-
   return (
     <ul className={classes}>
-      {reviewCount}
       {reviews.map(r => {
         return (
           <li key={`Review_${r.id.uuid}`} className={css.reviewItem}>

--- a/src/containers/ListingPage/ListingPage.js
+++ b/src/containers/ListingPage/ListingPage.js
@@ -30,6 +30,7 @@ import SectionHostMaybe from './SectionHostMaybe';
 import SectionImages from './SectionImages';
 import SectionMapMaybe from './SectionMapMaybe';
 import SectionRegularlyOpenOn from './SectionRegularlyOpenOn';
+import SectionReviews from './SectionReviews';
 import SectionRulesMaybe from './SectionRulesMaybe';
 import SectionType from './SectionType';
 
@@ -437,7 +438,7 @@ export class ListingPageComponent extends Component {
                     publicData={publicData}
                     listingId={currentListing.id}
                   />
-                  {/* <SectionReviews reviews={reviews} fetchReviewsError={fetchReviewsError} /> */}
+                  <SectionReviews reviews={reviews} fetchReviewsError={fetchReviewsError} />
                   <SectionHostMaybe
                     title={title}
                     listing={currentListing}


### PR DESCRIPTION
**What has been done**: Changed listing page to show reviews on the right and at the very bottom of the listing. The review below the booking panel is also hidden on mobile. 
**Pushed to**: (staging)
**Tag somebody**: @Shane-Walsh 
**PR**: (create a PR if the branch is ready to be merged)

**Asking for validation**: 

- Check on mobile and on a desktop if the issue has been correctly fixed.
- If everything is correct, move the card to the accepted column.
- If the issue isn't fixed, re-open the comment clearly what the problem is and what is the desired result. 
- Move the card to have issues column.
- Merge (or express approval in) the corresponding PR if needed. Move the card to the launch column.