### PR TITLE
Fixed links to "Guidebook", "Benefits" and "First Steps"

### DIFF
--- a/src/components/FirstStepsTabs/FirstStepsTabs.js
+++ b/src/components/FirstStepsTabs/FirstStepsTabs.js
@@ -19,7 +19,7 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const forUser = () => (
+const ForUser = () => (
   <TabContainer>
     <h2>We know more about you than you think.</h2>
     <p>
@@ -92,7 +92,7 @@ const forUser = () => (
   </TabContainer>
 );
 
-const forProvider = () => (
+const ForProvider = () => (
   <TabContainer>
     <h2>Higher income, more exposure, returning customers.</h2>
     <p>
@@ -157,7 +157,7 @@ const forProvider = () => (
     <p>
       If you're ready to start but you still have questions that are not covered by our{' '}
       <NamedLink name="FAQPage">help center</NamedLink>, we invite you to{' '}
-      <NamedLink name="ContactUsPages">contact us</NamedLink> and we'll assist you personally.
+      <NamedLink name="ContactUsPage">contact us</NamedLink> and we'll assist you personally.
     </p>
     <br />
   </TabContainer>
@@ -179,8 +179,8 @@ class FirstStepsTabs extends React.Component {
   render() {
 
     const tabs = {
-      0: <forUser />,
-      1: <forProvider />,
+      0: <ForUser />,
+      1: <ForProvider />,
     };
 
     const selectedTab = tabs[this.state.value];

--- a/src/containers/HelpCenter/DealsHelpPage/DealsHelpPage.js
+++ b/src/containers/HelpCenter/DealsHelpPage/DealsHelpPage.js
@@ -65,7 +65,7 @@ const DealsHelpPageComponent = props => {
             <NamedLink name="BirthdayDealPage">Birthday Gift</NamedLink>, you can reward your
             employees and colleagues with our{' '}
             <NamedLink name="CorporateDealPage">Corporate Benefit</NamedLink> or you can get a €15
-            gift card with our <NamedLink name="RecommandDealPage">Recommend Reward</NamedLink>.
+            gift card with our <NamedLink name="RecommendDealPage">Recommend Reward</NamedLink>.
           </p>
           <p>
             What are you waiting for?{' '}

--- a/src/containers/HelpCenter/GuidebookForProvidersPage/GuidebookForProvidersPage.js
+++ b/src/containers/HelpCenter/GuidebookForProvidersPage/GuidebookForProvidersPage.js
@@ -65,7 +65,7 @@ const GuidebookForProvidersPageComponent = props => {
             listing(s).
           </p>
           <p>
-            On our <NamedLink href="FirstStepPage">First Steps</NamedLink> page you can read about
+            On our <NamedLink name="FirstStepsPage">First Steps</NamedLink> page you can read about
             the first steps you need to make, to start listing your pub on Whichost.
           </p>
           <br />
@@ -73,7 +73,7 @@ const GuidebookForProvidersPageComponent = props => {
           <p>
             If you still have questions that are not covered by our{' '}
             <NamedLink name="FAQPage">help center</NamedLink>, we invite you to{' '}
-            <NamedLink href="ContactUsPage">contact us</NamedLink> and we'll assist you personally.
+            <NamedLink name="ContactUsPage">contact us</NamedLink> and we'll assist you personally.
           </p>
           <br />
         </LayoutWrapperMain>

--- a/src/forms/ContactUsForm/ContactUsForm.js
+++ b/src/forms/ContactUsForm/ContactUsForm.js
@@ -569,7 +569,7 @@ class ContactUsFormComponent extends Component {
                     <option value="privacy">Privacy Enquiry</option>
                     <option value="changePaymentInfo">Change payement informations</option>
                     <option value="corporate">Corporate Benefits Enquiries</option>
-                    <option value="recommandPub">Recommand a pub</option>
+                    <option value="recommendPub">Recommend a pub</option>
                   </FieldSelect>
 
                   {emailField}


### PR DESCRIPTION
Closes #290 

- React doesn't accept lowercase component names, so this was preventing the `<FirstStepsTabs />` from rendering

- Use of `href` rather than `name` for `<NamedLinks />` was preventing the Guidebook page from rendering

- Incorrect spelling of "recommend" was preventing the Benefits page from rendering